### PR TITLE
nix(deps): update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1669834992,
-        "narHash": "sha256-YnhZGHgb4C3Q7DSGisO/stc50jFb9F/MzHeKS4giotg=",
+        "lastModified": 1670461440,
+        "narHash": "sha256-jy1LB8HOMKGJEGXgzFRLDU1CBGL0/LlkolgnqIsF0D8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "596a8e828c5dfa504f91918d0fa4152db3ab5502",
+        "rev": "04a75b2eecc0acf6239acf9dd04485ff8d14f425",
         "type": "github"
       },
       "original": {

--- a/pkgs/_sources/generated.json
+++ b/pkgs/_sources/generated.json
@@ -59,11 +59,11 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-SabhpI8QV6dvLdGhvRFxLihZSTkX8mN1R3p+/CTK6bE=",
+            "sha256": "sha256-9Nc/50F11OlFV8iiy0LAjlZdwpC65H4O9oHbJlItSGE=",
             "type": "url",
-            "url": "https://releases.nixos.org/nixos/22.11/nixos-22.11.466.596a8e828c5/nixexprs.tar.xz"
+            "url": "https://releases.nixos.org/nixos/22.11/nixos-22.11.726.04a75b2eecc/nixexprs.tar.xz"
         },
-        "version": "22.11.466.596a8e828c5"
+        "version": "22.11.726.04a75b2eecc"
     },
     "remote-containers": {
         "cargoLocks": null,
@@ -78,12 +78,12 @@
         },
         "pinned": false,
         "src": {
-            "name": "remote-containers-0.266.0.zip",
-            "sha256": "sha256-XTt3qRuNXw6IAFj9QrblX3SnWeX771Dw/nY7eq3v8gA=",
+            "name": "remote-containers-0.267.0.zip",
+            "sha256": "sha256-glnDdEsvlmcux+ZO9uyhBZHCey6ge6+nQ1GCXSvqLoM=",
             "type": "url",
-            "url": "https://ms-vscode-remote.gallery.vsassets.io/_apis/public/gallery/publisher/ms-vscode-remote/extension/remote-containers/0.266.0/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage"
+            "url": "https://ms-vscode-remote.gallery.vsassets.io/_apis/public/gallery/publisher/ms-vscode-remote/extension/remote-containers/0.267.0/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage"
         },
-        "version": "0.266.0"
+        "version": "0.267.0"
     },
     "ubootPhicommN1": {
         "cargoLocks": null,

--- a/pkgs/_sources/generated.nix
+++ b/pkgs/_sources/generated.nix
@@ -33,19 +33,19 @@
   };
   programs-db = {
     pname = "programs-db";
-    version = "22.11.466.596a8e828c5";
+    version = "22.11.726.04a75b2eecc";
     src = fetchurl {
-      url = "https://releases.nixos.org/nixos/22.11/nixos-22.11.466.596a8e828c5/nixexprs.tar.xz";
-      sha256 = "sha256-SabhpI8QV6dvLdGhvRFxLihZSTkX8mN1R3p+/CTK6bE=";
+      url = "https://releases.nixos.org/nixos/22.11/nixos-22.11.726.04a75b2eecc/nixexprs.tar.xz";
+      sha256 = "sha256-9Nc/50F11OlFV8iiy0LAjlZdwpC65H4O9oHbJlItSGE=";
     };
   };
   remote-containers = {
     pname = "remote-containers";
-    version = "0.266.0";
+    version = "0.267.0";
     src = fetchurl {
-      url = "https://ms-vscode-remote.gallery.vsassets.io/_apis/public/gallery/publisher/ms-vscode-remote/extension/remote-containers/0.266.0/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage";
-      name = "remote-containers-0.266.0.zip";
-      sha256 = "sha256-XTt3qRuNXw6IAFj9QrblX3SnWeX771Dw/nY7eq3v8gA=";
+      url = "https://ms-vscode-remote.gallery.vsassets.io/_apis/public/gallery/publisher/ms-vscode-remote/extension/remote-containers/0.267.0/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage";
+      name = "remote-containers-0.267.0.zip";
+      sha256 = "sha256-glnDdEsvlmcux+ZO9uyhBZHCey6ge6+nQ1GCXSvqLoM=";
     };
     license = "free";
     homepage = "https://github.com/Microsoft/vscode-remote-release";


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/596a8e828c5dfa504f91918d0fa4152db3ab5502' (2022-11-30)
  → 'github:NixOS/nixpkgs/04a75b2eecc0acf6239acf9dd04485ff8d14f425' (2022-12-08)

Nvfetcher updates:

programs-db: 22.11.466.596a8e828c5 → 22.11.726.04a75b2eecc
remote-containers: 0.266.0 → 0.267.0