### PR TITLE
nix(deps): update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1670461440,
-        "narHash": "sha256-jy1LB8HOMKGJEGXgzFRLDU1CBGL0/LlkolgnqIsF0D8=",
+        "lastModified": 1671122953,
+        "narHash": "sha256-SVWmiyX2wx6BAxo4zMfRqDgFoWf4d3Vx1MgG/Vo4jL4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "04a75b2eecc0acf6239acf9dd04485ff8d14f425",
+        "rev": "0152de25d49dc16883b65f3e29cfea8d32f68956",
         "type": "github"
       },
       "original": {

--- a/pkgs/_sources/generated.json
+++ b/pkgs/_sources/generated.json
@@ -26,11 +26,11 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-si/RzJvXbAcG7Wyv780Hwr+1oiWB+uvc2RYbnYpE0MA=",
+            "sha256": "sha256-pApPPRIvG8qak5chupTN2u1IUKANXtkcEMlSAPedjH4=",
             "type": "url",
-            "url": "https://github.com/Dreamacro/maxmind-geoip/releases/download/20221112/Country.mmdb"
+            "url": "https://github.com/Dreamacro/maxmind-geoip/releases/download/20221212/Country.mmdb"
         },
-        "version": "20221112"
+        "version": "20221212"
     },
     "material-fox": {
         "cargoLocks": null,
@@ -59,11 +59,11 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-9Nc/50F11OlFV8iiy0LAjlZdwpC65H4O9oHbJlItSGE=",
+            "sha256": "sha256-EE2KQ4/ry10RGGZ4ZPyyjaxpSB92XhnBy79PE7xmwxY=",
             "type": "url",
-            "url": "https://releases.nixos.org/nixos/22.11/nixos-22.11.726.04a75b2eecc/nixexprs.tar.xz"
+            "url": "https://releases.nixos.org/nixos/22.11/nixos-22.11.964.0152de25d49/nixexprs.tar.xz"
         },
-        "version": "22.11.726.04a75b2eecc"
+        "version": "22.11.964.0152de25d49"
     },
     "remote-containers": {
         "cargoLocks": null,
@@ -78,12 +78,12 @@
         },
         "pinned": false,
         "src": {
-            "name": "remote-containers-0.267.0.zip",
-            "sha256": "sha256-glnDdEsvlmcux+ZO9uyhBZHCey6ge6+nQ1GCXSvqLoM=",
+            "name": "remote-containers-0.268.0.zip",
+            "sha256": "sha256-nxkDySKop9Z4py7QNX7T7TuDAw2t+1DpqyuB3a485Go=",
             "type": "url",
-            "url": "https://ms-vscode-remote.gallery.vsassets.io/_apis/public/gallery/publisher/ms-vscode-remote/extension/remote-containers/0.267.0/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage"
+            "url": "https://ms-vscode-remote.gallery.vsassets.io/_apis/public/gallery/publisher/ms-vscode-remote/extension/remote-containers/0.268.0/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage"
         },
-        "version": "0.267.0"
+        "version": "0.268.0"
     },
     "ubootPhicommN1": {
         "cargoLocks": null,

--- a/pkgs/_sources/generated.nix
+++ b/pkgs/_sources/generated.nix
@@ -14,10 +14,10 @@
   };
   clash-geoip = {
     pname = "clash-geoip";
-    version = "20221112";
+    version = "20221212";
     src = fetchurl {
-      url = "https://github.com/Dreamacro/maxmind-geoip/releases/download/20221112/Country.mmdb";
-      sha256 = "sha256-si/RzJvXbAcG7Wyv780Hwr+1oiWB+uvc2RYbnYpE0MA=";
+      url = "https://github.com/Dreamacro/maxmind-geoip/releases/download/20221212/Country.mmdb";
+      sha256 = "sha256-pApPPRIvG8qak5chupTN2u1IUKANXtkcEMlSAPedjH4=";
     };
   };
   material-fox = {
@@ -33,19 +33,19 @@
   };
   programs-db = {
     pname = "programs-db";
-    version = "22.11.726.04a75b2eecc";
+    version = "22.11.964.0152de25d49";
     src = fetchurl {
-      url = "https://releases.nixos.org/nixos/22.11/nixos-22.11.726.04a75b2eecc/nixexprs.tar.xz";
-      sha256 = "sha256-9Nc/50F11OlFV8iiy0LAjlZdwpC65H4O9oHbJlItSGE=";
+      url = "https://releases.nixos.org/nixos/22.11/nixos-22.11.964.0152de25d49/nixexprs.tar.xz";
+      sha256 = "sha256-EE2KQ4/ry10RGGZ4ZPyyjaxpSB92XhnBy79PE7xmwxY=";
     };
   };
   remote-containers = {
     pname = "remote-containers";
-    version = "0.267.0";
+    version = "0.268.0";
     src = fetchurl {
-      url = "https://ms-vscode-remote.gallery.vsassets.io/_apis/public/gallery/publisher/ms-vscode-remote/extension/remote-containers/0.267.0/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage";
-      name = "remote-containers-0.267.0.zip";
-      sha256 = "sha256-glnDdEsvlmcux+ZO9uyhBZHCey6ge6+nQ1GCXSvqLoM=";
+      url = "https://ms-vscode-remote.gallery.vsassets.io/_apis/public/gallery/publisher/ms-vscode-remote/extension/remote-containers/0.268.0/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage";
+      name = "remote-containers-0.268.0.zip";
+      sha256 = "sha256-nxkDySKop9Z4py7QNX7T7TuDAw2t+1DpqyuB3a485Go=";
     };
     license = "free";
     homepage = "https://github.com/Microsoft/vscode-remote-release";


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/04a75b2eecc0acf6239acf9dd04485ff8d14f425' (2022-12-08)
  → 'github:NixOS/nixpkgs/0152de25d49dc16883b65f3e29cfea8d32f68956' (2022-12-15)

Nvfetcher updates:

clash-geoip: 20221112 → 20221212
remote-containers: 0.267.0 → 0.268.0
programs-db: 22.11.726.04a75b2eecc → 22.11.964.0152de25d49