### PR TITLE
nix(deps): update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1671122953,
-        "narHash": "sha256-SVWmiyX2wx6BAxo4zMfRqDgFoWf4d3Vx1MgG/Vo4jL4=",
+        "lastModified": 1671525405,
+        "narHash": "sha256-MEgNxm/oRt5w4ycMENewfZQKOak0ixmjVPfXM96N1FA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0152de25d49dc16883b65f3e29cfea8d32f68956",
+        "rev": "cbe419ed4c8f98bd82d169c321d339ea30904f1f",
         "type": "github"
       },
       "original": {

--- a/pkgs/_sources/generated.json
+++ b/pkgs/_sources/generated.json
@@ -59,11 +59,11 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-EE2KQ4/ry10RGGZ4ZPyyjaxpSB92XhnBy79PE7xmwxY=",
+            "sha256": "sha256-XNIybKW5zA7KhqlkDOor4zERHZP+KMDfk6gz96AhzUs=",
             "type": "url",
-            "url": "https://releases.nixos.org/nixos/22.11/nixos-22.11.964.0152de25d49/nixexprs.tar.xz"
+            "url": "https://releases.nixos.org/nixos/22.11/nixos-22.11.1069.cbe419ed4c8/nixexprs.tar.xz"
         },
-        "version": "22.11.964.0152de25d49"
+        "version": "22.11.1069.cbe419ed4c8"
     },
     "remote-containers": {
         "cargoLocks": null,

--- a/pkgs/_sources/generated.nix
+++ b/pkgs/_sources/generated.nix
@@ -33,10 +33,10 @@
   };
   programs-db = {
     pname = "programs-db";
-    version = "22.11.964.0152de25d49";
+    version = "22.11.1069.cbe419ed4c8";
     src = fetchurl {
-      url = "https://releases.nixos.org/nixos/22.11/nixos-22.11.964.0152de25d49/nixexprs.tar.xz";
-      sha256 = "sha256-EE2KQ4/ry10RGGZ4ZPyyjaxpSB92XhnBy79PE7xmwxY=";
+      url = "https://releases.nixos.org/nixos/22.11/nixos-22.11.1069.cbe419ed4c8/nixexprs.tar.xz";
+      sha256 = "sha256-XNIybKW5zA7KhqlkDOor4zERHZP+KMDfk6gz96AhzUs=";
     };
   };
   remote-containers = {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/0152de25d49dc16883b65f3e29cfea8d32f68956' (2022-12-15)
  → 'github:NixOS/nixpkgs/cbe419ed4c8f98bd82d169c321d339ea30904f1f' (2022-12-20)

Nvfetcher updates:

programs-db: 22.11.964.0152de25d49 → 22.11.1069.cbe419ed4c8