### PR TITLE
nix(deps): update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1671525405,
-        "narHash": "sha256-MEgNxm/oRt5w4ycMENewfZQKOak0ixmjVPfXM96N1FA=",
+        "lastModified": 1672170105,
+        "narHash": "sha256-RabUtQyG7VCTlWgSu8/nzfF48sWaoO9xAPpRRoVDd18=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cbe419ed4c8f98bd82d169c321d339ea30904f1f",
+        "rev": "619a61fcfde0cce679708b8644d136e455e84eac",
         "type": "github"
       },
       "original": {

--- a/pkgs/_sources/generated.json
+++ b/pkgs/_sources/generated.json
@@ -59,11 +59,11 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-XNIybKW5zA7KhqlkDOor4zERHZP+KMDfk6gz96AhzUs=",
+            "sha256": "sha256-S/BPHfoJzWyTBitfZ8yemwfNsM2fCwLsE41D0wVgVnQ=",
             "type": "url",
-            "url": "https://releases.nixos.org/nixos/22.11/nixos-22.11.1069.cbe419ed4c8/nixexprs.tar.xz"
+            "url": "https://releases.nixos.org/nixos/22.11/nixos-22.11.1169.619a61fcfde/nixexprs.tar.xz"
         },
-        "version": "22.11.1069.cbe419ed4c8"
+        "version": "22.11.1169.619a61fcfde"
     },
     "remote-containers": {
         "cargoLocks": null,
@@ -78,12 +78,12 @@
         },
         "pinned": false,
         "src": {
-            "name": "remote-containers-0.268.0.zip",
-            "sha256": "sha256-nxkDySKop9Z4py7QNX7T7TuDAw2t+1DpqyuB3a485Go=",
+            "name": "remote-containers-0.269.0.zip",
+            "sha256": "sha256-8HY46AKbAU5W01BN4iwCUSFqTXfRbC937Gy0kvPTmn4=",
             "type": "url",
-            "url": "https://ms-vscode-remote.gallery.vsassets.io/_apis/public/gallery/publisher/ms-vscode-remote/extension/remote-containers/0.268.0/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage"
+            "url": "https://ms-vscode-remote.gallery.vsassets.io/_apis/public/gallery/publisher/ms-vscode-remote/extension/remote-containers/0.269.0/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage"
         },
-        "version": "0.268.0"
+        "version": "0.269.0"
     },
     "ubootPhicommN1": {
         "cargoLocks": null,

--- a/pkgs/_sources/generated.nix
+++ b/pkgs/_sources/generated.nix
@@ -33,19 +33,19 @@
   };
   programs-db = {
     pname = "programs-db";
-    version = "22.11.1069.cbe419ed4c8";
+    version = "22.11.1169.619a61fcfde";
     src = fetchurl {
-      url = "https://releases.nixos.org/nixos/22.11/nixos-22.11.1069.cbe419ed4c8/nixexprs.tar.xz";
-      sha256 = "sha256-XNIybKW5zA7KhqlkDOor4zERHZP+KMDfk6gz96AhzUs=";
+      url = "https://releases.nixos.org/nixos/22.11/nixos-22.11.1169.619a61fcfde/nixexprs.tar.xz";
+      sha256 = "sha256-S/BPHfoJzWyTBitfZ8yemwfNsM2fCwLsE41D0wVgVnQ=";
     };
   };
   remote-containers = {
     pname = "remote-containers";
-    version = "0.268.0";
+    version = "0.269.0";
     src = fetchurl {
-      url = "https://ms-vscode-remote.gallery.vsassets.io/_apis/public/gallery/publisher/ms-vscode-remote/extension/remote-containers/0.268.0/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage";
-      name = "remote-containers-0.268.0.zip";
-      sha256 = "sha256-nxkDySKop9Z4py7QNX7T7TuDAw2t+1DpqyuB3a485Go=";
+      url = "https://ms-vscode-remote.gallery.vsassets.io/_apis/public/gallery/publisher/ms-vscode-remote/extension/remote-containers/0.269.0/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage";
+      name = "remote-containers-0.269.0.zip";
+      sha256 = "sha256-8HY46AKbAU5W01BN4iwCUSFqTXfRbC937Gy0kvPTmn4=";
     };
     license = "free";
     homepage = "https://github.com/Microsoft/vscode-remote-release";


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/cbe419ed4c8f98bd82d169c321d339ea30904f1f' (2022-12-20)
  → 'github:NixOS/nixpkgs/619a61fcfde0cce679708b8644d136e455e84eac' (2022-12-27)

Nvfetcher updates:

remote-containers: 0.268.0 → 0.269.0
programs-db: 22.11.1069.cbe419ed4c8 → 22.11.1169.619a61fcfde