### PR TITLE
nix(deps): update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1672170105,
-        "narHash": "sha256-RabUtQyG7VCTlWgSu8/nzfF48sWaoO9xAPpRRoVDd18=",
+        "lastModified": 1672844754,
+        "narHash": "sha256-o26WabuHABQsaHxxmIrR3AQRqDFUEdLckLXkVCpIjSU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "619a61fcfde0cce679708b8644d136e455e84eac",
+        "rev": "e9ade2c8240e00a4784fac282a502efff2786bdc",
         "type": "github"
       },
       "original": {

--- a/pkgs/_sources/generated.json
+++ b/pkgs/_sources/generated.json
@@ -59,11 +59,11 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-S/BPHfoJzWyTBitfZ8yemwfNsM2fCwLsE41D0wVgVnQ=",
+            "sha256": "sha256-ZWPUOpDxQhaQxLzNMYzSuIjAInqqEAyF+Yy/TYHJ+YY=",
             "type": "url",
-            "url": "https://releases.nixos.org/nixos/22.11/nixos-22.11.1169.619a61fcfde/nixexprs.tar.xz"
+            "url": "https://releases.nixos.org/nixos/22.11/nixos-22.11.1421.e9ade2c8240/nixexprs.tar.xz"
         },
-        "version": "22.11.1169.619a61fcfde"
+        "version": "22.11.1421.e9ade2c8240"
     },
     "remote-containers": {
         "cargoLocks": null,
@@ -98,11 +98,11 @@
             "name": null,
             "owner": "cattyhouse",
             "repo": "new-uboot-for-N1",
-            "rev": "c28871d15a1a45cd6eb29aba1f7f4c8a0bbb6418",
-            "sha256": "sha256-bJjzK8FsUoi8w0ye1jviptXMG/AiL2YPwLPUoqIv7Nk=",
+            "rev": "83038e36425f1748d355ea56a0be1168b46aa7c4",
+            "sha256": "sha256-vsyF5fbzMtl8A3NRzNn5GHlvj+/oxmlQbQ4tUJEatmo=",
             "type": "github"
         },
-        "version": "c28871d15a1a45cd6eb29aba1f7f4c8a0bbb6418"
+        "version": "83038e36425f1748d355ea56a0be1168b46aa7c4"
     },
     "yacd": {
         "cargoLocks": null,

--- a/pkgs/_sources/generated.nix
+++ b/pkgs/_sources/generated.nix
@@ -33,10 +33,10 @@
   };
   programs-db = {
     pname = "programs-db";
-    version = "22.11.1169.619a61fcfde";
+    version = "22.11.1421.e9ade2c8240";
     src = fetchurl {
-      url = "https://releases.nixos.org/nixos/22.11/nixos-22.11.1169.619a61fcfde/nixexprs.tar.xz";
-      sha256 = "sha256-S/BPHfoJzWyTBitfZ8yemwfNsM2fCwLsE41D0wVgVnQ=";
+      url = "https://releases.nixos.org/nixos/22.11/nixos-22.11.1421.e9ade2c8240/nixexprs.tar.xz";
+      sha256 = "sha256-ZWPUOpDxQhaQxLzNMYzSuIjAInqqEAyF+Yy/TYHJ+YY=";
     };
   };
   remote-containers = {
@@ -55,13 +55,13 @@
   };
   ubootPhicommN1 = {
     pname = "ubootPhicommN1";
-    version = "c28871d15a1a45cd6eb29aba1f7f4c8a0bbb6418";
+    version = "83038e36425f1748d355ea56a0be1168b46aa7c4";
     src = fetchFromGitHub ({
       owner = "cattyhouse";
       repo = "new-uboot-for-N1";
-      rev = "c28871d15a1a45cd6eb29aba1f7f4c8a0bbb6418";
+      rev = "83038e36425f1748d355ea56a0be1168b46aa7c4";
       fetchSubmodules = false;
-      sha256 = "sha256-bJjzK8FsUoi8w0ye1jviptXMG/AiL2YPwLPUoqIv7Nk=";
+      sha256 = "sha256-vsyF5fbzMtl8A3NRzNn5GHlvj+/oxmlQbQ4tUJEatmo=";
     });
   };
   yacd = {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/619a61fcfde0cce679708b8644d136e455e84eac' (2022-12-27)
  → 'github:NixOS/nixpkgs/e9ade2c8240e00a4784fac282a502efff2786bdc' (2023-01-04)

Nvfetcher updates:

programs-db: 22.11.1169.619a61fcfde → 22.11.1421.e9ade2c8240
ubootPhicommN1: c28871d15a1a45cd6eb29aba1f7f4c8a0bbb6418 → 83038e36425f1748d355ea56a0be1168b46aa7c4