### PR TITLE
nix(deps): update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1673527292,
-        "narHash": "sha256-903EpRSDCfUvic7Hsiqwy+h7zlMTLAUbCXkEGGriCfM=",
+        "lastModified": 1674692158,
+        "narHash": "sha256-oqGpwVg4D+eMSgF7Th5Ve1ysCiH3H3g85vGJ3nvJsZQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6a3f9996408c970b99b8b992b11bb249d1455b62",
+        "rev": "def9e420d27c951026d57dc96ce0218c3131f412",
         "type": "github"
       },
       "original": {

--- a/pkgs/_sources/generated.json
+++ b/pkgs/_sources/generated.json
@@ -56,6 +56,7 @@
     },
     "motrix": {
         "cargoLocks": null,
+        "date": null,
         "extract": null,
         "name": "motrix",
         "passthru": null,
@@ -77,11 +78,11 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-biP9RzdYPr7U65uerzg9/TulKZcJANkjx/gk9dfJkaA=",
+            "sha256": "sha256-vytv1n/fk6SmIUVclAOMwa+A8lINkE4TNUqYD6mUvxY=",
             "type": "url",
-            "url": "https://releases.nixos.org/nixos/22.11/nixos-22.11.1574.6a3f9996408/nixexprs.tar.xz"
+            "url": "https://releases.nixos.org/nixos/22.11/nixos-22.11.2028.def9e420d27/nixexprs.tar.xz"
         },
-        "version": "22.11.1574.6a3f9996408"
+        "version": "22.11.2028.def9e420d27"
     },
     "remote-containers": {
         "cargoLocks": null,
@@ -97,12 +98,12 @@
         },
         "pinned": false,
         "src": {
-            "name": "remote-containers-0.270.0.zip",
-            "sha256": "sha256-UQ9g/vogA0b7ZMmOiiCdqPNDZQUdPd+3riy8QISNW3U=",
+            "name": "remote-containers-0.274.0.zip",
+            "sha256": "sha256-sIe6kB7lJYyaM0IecROxtUnorw3usPUN4pMtpLOc+ng=",
             "type": "url",
-            "url": "https://ms-vscode-remote.gallery.vsassets.io/_apis/public/gallery/publisher/ms-vscode-remote/extension/remote-containers/0.270.0/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage"
+            "url": "https://ms-vscode-remote.gallery.vsassets.io/_apis/public/gallery/publisher/ms-vscode-remote/extension/remote-containers/0.274.0/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage"
         },
-        "version": "0.270.0"
+        "version": "0.274.0"
     },
     "ubootPhicommN1": {
         "cargoLocks": null,

--- a/pkgs/_sources/generated.nix
+++ b/pkgs/_sources/generated.nix
@@ -41,19 +41,19 @@
   };
   programs-db = {
     pname = "programs-db";
-    version = "22.11.1574.6a3f9996408";
+    version = "22.11.2028.def9e420d27";
     src = fetchurl {
-      url = "https://releases.nixos.org/nixos/22.11/nixos-22.11.1574.6a3f9996408/nixexprs.tar.xz";
-      sha256 = "sha256-biP9RzdYPr7U65uerzg9/TulKZcJANkjx/gk9dfJkaA=";
+      url = "https://releases.nixos.org/nixos/22.11/nixos-22.11.2028.def9e420d27/nixexprs.tar.xz";
+      sha256 = "sha256-vytv1n/fk6SmIUVclAOMwa+A8lINkE4TNUqYD6mUvxY=";
     };
   };
   remote-containers = {
     pname = "remote-containers";
-    version = "0.270.0";
+    version = "0.274.0";
     src = fetchurl {
-      url = "https://ms-vscode-remote.gallery.vsassets.io/_apis/public/gallery/publisher/ms-vscode-remote/extension/remote-containers/0.270.0/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage";
-      name = "remote-containers-0.270.0.zip";
-      sha256 = "sha256-UQ9g/vogA0b7ZMmOiiCdqPNDZQUdPd+3riy8QISNW3U=";
+      url = "https://ms-vscode-remote.gallery.vsassets.io/_apis/public/gallery/publisher/ms-vscode-remote/extension/remote-containers/0.274.0/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage";
+      name = "remote-containers-0.274.0.zip";
+      sha256 = "sha256-sIe6kB7lJYyaM0IecROxtUnorw3usPUN4pMtpLOc+ng=";
     };
     license = "free";
     homepage = "https://github.com/Microsoft/vscode-remote-release";

--- a/pkgs/firefox-addons/addons.nix
+++ b/pkgs/firefox-addons/addons.nix
@@ -57,10 +57,10 @@
       };
     "rsshub-radar" = buildFirefoxXpiAddon {
       pname = "rsshub-radar";
-      version = "1.9.0";
+      version = "1.10.1";
       addonId = "i@diygod.me";
-      url = "https://addons.mozilla.org/firefox/downloads/file/4019770/rsshub_radar-1.9.0.xpi";
-      sha256 = "215d5830855b4827ec86c9de3f370c359adf49c195e76ba7b5306f5bb611acce";
+      url = "https://addons.mozilla.org/firefox/downloads/file/4056771/rsshub_radar-1.10.1.xpi";
+      sha256 = "6dc3c41ea1dd6079e9e26906803542180dbad4ff43a587afc91bc51b272dd736";
       meta = with lib;
       {
         homepage = "https://docs.rsshub.app";


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/6a3f9996408c970b99b8b992b11bb249d1455b62' (2023-01-12)
  → 'github:NixOS/nixpkgs/def9e420d27c951026d57dc96ce0218c3131f412' (2023-01-26)

Nvfetcher updates:

programs-db: 22.11.1574.6a3f9996408 → 22.11.2028.def9e420d27
remote-containers: 0.270.0 → 0.274.0