### PR TITLE
nix(deps): update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1674692158,
-        "narHash": "sha256-oqGpwVg4D+eMSgF7Th5Ve1ysCiH3H3g85vGJ3nvJsZQ=",
+        "lastModified": 1675237434,
+        "narHash": "sha256-YoFR0vyEa1HXufLNIFgOGhIFMRnY6aZ0IepZF5cYemo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "def9e420d27c951026d57dc96ce0218c3131f412",
+        "rev": "285b3ff0660640575186a4086e1f8dc0df2874b5",
         "type": "github"
       },
       "original": {

--- a/pkgs/_sources/generated.json
+++ b/pkgs/_sources/generated.json
@@ -78,11 +78,11 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-vytv1n/fk6SmIUVclAOMwa+A8lINkE4TNUqYD6mUvxY=",
+            "sha256": "sha256-E+obcF0s7KLUXCAW/9b3hqFS+g0YzNDPE0wbrLGFf1M=",
             "type": "url",
-            "url": "https://releases.nixos.org/nixos/22.11/nixos-22.11.2028.def9e420d27/nixexprs.tar.xz"
+            "url": "https://releases.nixos.org/nixos/22.11/nixos-22.11.2203.285b3ff0660/nixexprs.tar.xz"
         },
-        "version": "22.11.2028.def9e420d27"
+        "version": "22.11.2203.285b3ff0660"
     },
     "remote-containers": {
         "cargoLocks": null,

--- a/pkgs/_sources/generated.nix
+++ b/pkgs/_sources/generated.nix
@@ -41,10 +41,10 @@
   };
   programs-db = {
     pname = "programs-db";
-    version = "22.11.2028.def9e420d27";
+    version = "22.11.2203.285b3ff0660";
     src = fetchurl {
-      url = "https://releases.nixos.org/nixos/22.11/nixos-22.11.2028.def9e420d27/nixexprs.tar.xz";
-      sha256 = "sha256-vytv1n/fk6SmIUVclAOMwa+A8lINkE4TNUqYD6mUvxY=";
+      url = "https://releases.nixos.org/nixos/22.11/nixos-22.11.2203.285b3ff0660/nixexprs.tar.xz";
+      sha256 = "sha256-E+obcF0s7KLUXCAW/9b3hqFS+g0YzNDPE0wbrLGFf1M=";
     };
   };
   remote-containers = {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/def9e420d27c951026d57dc96ce0218c3131f412' (2023-01-26)
  → 'github:NixOS/nixpkgs/285b3ff0660640575186a4086e1f8dc0df2874b5' (2023-02-01)

Nvfetcher updates:

programs-db: 22.11.2028.def9e420d27 → 22.11.2203.285b3ff0660