### PR TITLE
nix(deps): update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1675237434,
-        "narHash": "sha256-YoFR0vyEa1HXufLNIFgOGhIFMRnY6aZ0IepZF5cYemo=",
+        "lastModified": 1675918889,
+        "narHash": "sha256-hy7re4F9AEQqwZxubct7jBRos6md26bmxnCjxf5utJA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "285b3ff0660640575186a4086e1f8dc0df2874b5",
+        "rev": "49efda9011e8cdcd6c1aad30384cb1dc230c82fe",
         "type": "github"
       },
       "original": {

--- a/pkgs/_sources/generated.json
+++ b/pkgs/_sources/generated.json
@@ -13,11 +13,11 @@
             "name": null,
             "owner": "arkenfox",
             "repo": "user.js",
-            "rev": "108.0",
-            "sha256": "sha256-YsQbH6bqp2I52meYf0X0DQpwLlDdu5pK9XHMT/9RqOg=",
+            "rev": "109.0",
+            "sha256": "sha256-ebSx6DaXoGKcCoK6UcDnWvdAW6J2X6pJRPD1Pw7UNOw=",
             "type": "github"
         },
-        "version": "108.0"
+        "version": "109.0"
     },
     "clash-geoip": {
         "cargoLocks": null,
@@ -78,11 +78,11 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-E+obcF0s7KLUXCAW/9b3hqFS+g0YzNDPE0wbrLGFf1M=",
+            "sha256": "sha256-+7LgdhUVQdXyw8MDS7j7szR57hp6YAXDIqGrTFjUdQA=",
             "type": "url",
-            "url": "https://releases.nixos.org/nixos/22.11/nixos-22.11.2203.285b3ff0660/nixexprs.tar.xz"
+            "url": "https://releases.nixos.org/nixos/22.11/nixos-22.11.2345.af96094e9b8/nixexprs.tar.xz"
         },
-        "version": "22.11.2203.285b3ff0660"
+        "version": "22.11.2345.af96094e9b8"
     },
     "remote-containers": {
         "cargoLocks": null,

--- a/pkgs/_sources/generated.nix
+++ b/pkgs/_sources/generated.nix
@@ -3,13 +3,13 @@
 {
   arkenfox-userjs = {
     pname = "arkenfox-userjs";
-    version = "108.0";
+    version = "109.0";
     src = fetchFromGitHub ({
       owner = "arkenfox";
       repo = "user.js";
-      rev = "108.0";
+      rev = "109.0";
       fetchSubmodules = false;
-      sha256 = "sha256-YsQbH6bqp2I52meYf0X0DQpwLlDdu5pK9XHMT/9RqOg=";
+      sha256 = "sha256-ebSx6DaXoGKcCoK6UcDnWvdAW6J2X6pJRPD1Pw7UNOw=";
     });
   };
   clash-geoip = {
@@ -41,10 +41,10 @@
   };
   programs-db = {
     pname = "programs-db";
-    version = "22.11.2203.285b3ff0660";
+    version = "22.11.2345.af96094e9b8";
     src = fetchurl {
-      url = "https://releases.nixos.org/nixos/22.11/nixos-22.11.2203.285b3ff0660/nixexprs.tar.xz";
-      sha256 = "sha256-E+obcF0s7KLUXCAW/9b3hqFS+g0YzNDPE0wbrLGFf1M=";
+      url = "https://releases.nixos.org/nixos/22.11/nixos-22.11.2345.af96094e9b8/nixexprs.tar.xz";
+      sha256 = "sha256-+7LgdhUVQdXyw8MDS7j7szR57hp6YAXDIqGrTFjUdQA=";
     };
   };
   remote-containers = {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/285b3ff0660640575186a4086e1f8dc0df2874b5' (2023-02-01)
  → 'github:NixOS/nixpkgs/49efda9011e8cdcd6c1aad30384cb1dc230c82fe' (2023-02-09)

Nvfetcher updates:

programs-db: 22.11.2203.285b3ff0660 → 22.11.2345.af96094e9b8
arkenfox-userjs: 108.0 → 109.0