### PR TITLE
nix(deps): update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1676375384,
-        "narHash": "sha256-6HI3jZiuJX+KLz05cocYy2mBAWlISEKHU84ftYfxHZ8=",
+        "lastModified": 1677075010,
+        "narHash": "sha256-X+UmR1AkdR//lPVcShmLy8p1n857IGf7y+cyCArp8bU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c43f676c938662072772339be6269226c77b51b8",
+        "rev": "c95bf18beba4290af25c60cbaaceea1110d0f727",
         "type": "github"
       },
       "original": {

--- a/pkgs/_sources/generated.json
+++ b/pkgs/_sources/generated.json
@@ -93,11 +93,11 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-bK5ww6z57BZTw/0AvG65tGumXyvWNJS8BJNLpE35m6k=",
+            "sha256": "sha256-kbtA1CiRSWEnClLejVlbN/VgGl5ThiaSZIacah9UqU0=",
             "type": "url",
-            "url": "https://releases.nixos.org/nixos/22.11/nixos-22.11.2568.c43f676c938/nixexprs.tar.xz"
+            "url": "https://releases.nixos.org/nixos/22.11/nixos-22.11.2712.c95bf18beba/nixexprs.tar.xz"
         },
-        "version": "22.11.2568.c43f676c938"
+        "version": "22.11.2712.c95bf18beba"
     },
     "remote-containers": {
         "cargoLocks": null,

--- a/pkgs/_sources/generated.nix
+++ b/pkgs/_sources/generated.nix
@@ -49,10 +49,10 @@
   };
   programs-db = {
     pname = "programs-db";
-    version = "22.11.2568.c43f676c938";
+    version = "22.11.2712.c95bf18beba";
     src = fetchurl {
-      url = "https://releases.nixos.org/nixos/22.11/nixos-22.11.2568.c43f676c938/nixexprs.tar.xz";
-      sha256 = "sha256-bK5ww6z57BZTw/0AvG65tGumXyvWNJS8BJNLpE35m6k=";
+      url = "https://releases.nixos.org/nixos/22.11/nixos-22.11.2712.c95bf18beba/nixexprs.tar.xz";
+      sha256 = "sha256-kbtA1CiRSWEnClLejVlbN/VgGl5ThiaSZIacah9UqU0=";
     };
   };
   remote-containers = {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/c43f676c938662072772339be6269226c77b51b8' (2023-02-14)
  → 'github:NixOS/nixpkgs/c95bf18beba4290af25c60cbaaceea1110d0f727' (2023-02-22)

Nvfetcher updates:

programs-db: 22.11.2568.c43f676c938 → 22.11.2712.c95bf18beba