### PR TITLE
nix(deps): update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1677075010,
-        "narHash": "sha256-X+UmR1AkdR//lPVcShmLy8p1n857IGf7y+cyCArp8bU=",
+        "lastModified": 1677779205,
+        "narHash": "sha256-6DBjL9wjq86p2GczmwnHtFRnWPBPItc67gapWENBgX8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c95bf18beba4290af25c60cbaaceea1110d0f727",
+        "rev": "96e18717904dfedcd884541e5a92bf9ff632cf39",
         "type": "github"
       },
       "original": {

--- a/pkgs/_sources/generated.json
+++ b/pkgs/_sources/generated.json
@@ -93,11 +93,11 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-kbtA1CiRSWEnClLejVlbN/VgGl5ThiaSZIacah9UqU0=",
+            "sha256": "sha256-IahUkG8ttAXdSvcfbJRZILwXREtSJAdF1V64+k+w84w=",
             "type": "url",
-            "url": "https://releases.nixos.org/nixos/22.11/nixos-22.11.2712.c95bf18beba/nixexprs.tar.xz"
+            "url": "https://releases.nixos.org/nixos/22.11/nixos-22.11.2939.96e18717904/nixexprs.tar.xz"
         },
-        "version": "22.11.2712.c95bf18beba"
+        "version": "22.11.2939.96e18717904"
     },
     "remote-containers": {
         "cargoLocks": null,

--- a/pkgs/_sources/generated.nix
+++ b/pkgs/_sources/generated.nix
@@ -49,10 +49,10 @@
   };
   programs-db = {
     pname = "programs-db";
-    version = "22.11.2712.c95bf18beba";
+    version = "22.11.2939.96e18717904";
     src = fetchurl {
-      url = "https://releases.nixos.org/nixos/22.11/nixos-22.11.2712.c95bf18beba/nixexprs.tar.xz";
-      sha256 = "sha256-kbtA1CiRSWEnClLejVlbN/VgGl5ThiaSZIacah9UqU0=";
+      url = "https://releases.nixos.org/nixos/22.11/nixos-22.11.2939.96e18717904/nixexprs.tar.xz";
+      sha256 = "sha256-IahUkG8ttAXdSvcfbJRZILwXREtSJAdF1V64+k+w84w=";
     };
   };
   remote-containers = {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/c95bf18beba4290af25c60cbaaceea1110d0f727' (2023-02-22)
  → 'github:NixOS/nixpkgs/96e18717904dfedcd884541e5a92bf9ff632cf39' (2023-03-02)

Nvfetcher updates:

programs-db: 22.11.2712.c95bf18beba → 22.11.2939.96e18717904