### PR TITLE
nix(deps): update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1677779205,
-        "narHash": "sha256-6DBjL9wjq86p2GczmwnHtFRnWPBPItc67gapWENBgX8=",
+        "lastModified": 1678230755,
+        "narHash": "sha256-SFAXgNjNTXzcAideXcP0takfUGVft/VR5CACmYHg+Fc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "96e18717904dfedcd884541e5a92bf9ff632cf39",
+        "rev": "a7cc81913bb3cd1ef05ed0ece048b773e1839e51",
         "type": "github"
       },
       "original": {

--- a/pkgs/_sources/generated.json
+++ b/pkgs/_sources/generated.json
@@ -93,11 +93,11 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-IahUkG8ttAXdSvcfbJRZILwXREtSJAdF1V64+k+w84w=",
+            "sha256": "sha256-jS8Di/7apcm5jEaFR3Uz9MQQ5eljhUwrg6VSAtUcnMk=",
             "type": "url",
-            "url": "https://releases.nixos.org/nixos/22.11/nixos-22.11.2939.96e18717904/nixexprs.tar.xz"
+            "url": "https://releases.nixos.org/nixos/22.11/nixos-22.11.2999.a7cc81913bb/nixexprs.tar.xz"
         },
-        "version": "22.11.2939.96e18717904"
+        "version": "22.11.2999.a7cc81913bb"
     },
     "remote-containers": {
         "cargoLocks": null,

--- a/pkgs/_sources/generated.nix
+++ b/pkgs/_sources/generated.nix
@@ -49,10 +49,10 @@
   };
   programs-db = {
     pname = "programs-db";
-    version = "22.11.2939.96e18717904";
+    version = "22.11.2999.a7cc81913bb";
     src = fetchurl {
-      url = "https://releases.nixos.org/nixos/22.11/nixos-22.11.2939.96e18717904/nixexprs.tar.xz";
-      sha256 = "sha256-IahUkG8ttAXdSvcfbJRZILwXREtSJAdF1V64+k+w84w=";
+      url = "https://releases.nixos.org/nixos/22.11/nixos-22.11.2999.a7cc81913bb/nixexprs.tar.xz";
+      sha256 = "sha256-jS8Di/7apcm5jEaFR3Uz9MQQ5eljhUwrg6VSAtUcnMk=";
     };
   };
   remote-containers = {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/96e18717904dfedcd884541e5a92bf9ff632cf39' (2023-03-02)
  → 'github:NixOS/nixpkgs/a7cc81913bb3cd1ef05ed0ece048b773e1839e51' (2023-03-07)

Nvfetcher updates:

programs-db: 22.11.2939.96e18717904 → 22.11.2999.a7cc81913bb