### PR TITLE
nix(deps): update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1676283394,
-        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1678230755,
-        "narHash": "sha256-SFAXgNjNTXzcAideXcP0takfUGVft/VR5CACmYHg+Fc=",
+        "lastModified": 1678872516,
+        "narHash": "sha256-/E1YwtMtFAu2KUQKV/1+KFuReYPANM2Rzehk84VxVoc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a7cc81913bb3cd1ef05ed0ece048b773e1839e51",
+        "rev": "9b8e5abb18324c7fe9f07cb100c3cd4a29cda8b8",
         "type": "github"
       },
       "original": {

--- a/pkgs/_sources/generated.json
+++ b/pkgs/_sources/generated.json
@@ -13,11 +13,11 @@
             "name": null,
             "owner": "arkenfox",
             "repo": "user.js",
-            "rev": "109.0",
-            "sha256": "sha256-ebSx6DaXoGKcCoK6UcDnWvdAW6J2X6pJRPD1Pw7UNOw=",
+            "rev": "110.0",
+            "sha256": "sha256-pPJH69y29aV1fc3lrlPl5pMLB5ntem+DcAR3rx3gvDE=",
             "type": "github"
         },
-        "version": "109.0"
+        "version": "110.0"
     },
     "clash-geoip": {
         "cargoLocks": null,
@@ -28,11 +28,11 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-Tnma6tpET4Vrm5G8KmLpsVnpD2JIKts56kZQsBIbRZ8=",
+            "sha256": "sha256-Y/glz6HUfjox9Mn+gPzA8+tUHqV/KkIInUn4SyajUiE=",
             "type": "url",
-            "url": "https://github.com/Dreamacro/maxmind-geoip/releases/download/20230212/Country.mmdb"
+            "url": "https://github.com/Dreamacro/maxmind-geoip/releases/download/20230312/Country.mmdb"
         },
-        "version": "20230212"
+        "version": "20230312"
     },
     "clashctl": {
         "cargoLocks": null,
@@ -93,11 +93,11 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-jS8Di/7apcm5jEaFR3Uz9MQQ5eljhUwrg6VSAtUcnMk=",
+            "sha256": "sha256-eOgjJLRbqa1Omc75Ryjl9MJX4Y3uaHUmy7EjcCSw6CM=",
             "type": "url",
-            "url": "https://releases.nixos.org/nixos/22.11/nixos-22.11.2999.a7cc81913bb/nixexprs.tar.xz"
+            "url": "https://releases.nixos.org/nixos/22.11/nixos-22.11.3184.9b8e5abb183/nixexprs.tar.xz"
         },
-        "version": "22.11.2999.a7cc81913bb"
+        "version": "22.11.3184.9b8e5abb183"
     },
     "remote-containers": {
         "cargoLocks": null,

--- a/pkgs/_sources/generated.nix
+++ b/pkgs/_sources/generated.nix
@@ -3,21 +3,21 @@
 {
   arkenfox-userjs = {
     pname = "arkenfox-userjs";
-    version = "109.0";
+    version = "110.0";
     src = fetchFromGitHub ({
       owner = "arkenfox";
       repo = "user.js";
-      rev = "109.0";
+      rev = "110.0";
       fetchSubmodules = false;
-      sha256 = "sha256-ebSx6DaXoGKcCoK6UcDnWvdAW6J2X6pJRPD1Pw7UNOw=";
+      sha256 = "sha256-pPJH69y29aV1fc3lrlPl5pMLB5ntem+DcAR3rx3gvDE=";
     });
   };
   clash-geoip = {
     pname = "clash-geoip";
-    version = "20230212";
+    version = "20230312";
     src = fetchurl {
-      url = "https://github.com/Dreamacro/maxmind-geoip/releases/download/20230212/Country.mmdb";
-      sha256 = "sha256-Tnma6tpET4Vrm5G8KmLpsVnpD2JIKts56kZQsBIbRZ8=";
+      url = "https://github.com/Dreamacro/maxmind-geoip/releases/download/20230312/Country.mmdb";
+      sha256 = "sha256-Y/glz6HUfjox9Mn+gPzA8+tUHqV/KkIInUn4SyajUiE=";
     };
   };
   clashctl = {
@@ -49,10 +49,10 @@
   };
   programs-db = {
     pname = "programs-db";
-    version = "22.11.2999.a7cc81913bb";
+    version = "22.11.3184.9b8e5abb183";
     src = fetchurl {
-      url = "https://releases.nixos.org/nixos/22.11/nixos-22.11.2999.a7cc81913bb/nixexprs.tar.xz";
-      sha256 = "sha256-jS8Di/7apcm5jEaFR3Uz9MQQ5eljhUwrg6VSAtUcnMk=";
+      url = "https://releases.nixos.org/nixos/22.11/nixos-22.11.3184.9b8e5abb183/nixexprs.tar.xz";
+      sha256 = "sha256-eOgjJLRbqa1Omc75Ryjl9MJX4Y3uaHUmy7EjcCSw6CM=";
     };
   };
   remote-containers = {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'flake-utils':
    'github:numtide/flake-utils/3db36a8b464d0c4532ba1c7dda728f4576d6d073' (2023-02-13)
  → 'github:numtide/flake-utils/93a2b84fc4b70d9e089d029deacc3583435c2ed6' (2023-03-15)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/a7cc81913bb3cd1ef05ed0ece048b773e1839e51' (2023-03-07)
  → 'github:NixOS/nixpkgs/9b8e5abb18324c7fe9f07cb100c3cd4a29cda8b8' (2023-03-15)

Nvfetcher updates:

clash-geoip: 20230212 → 20230312
programs-db: 22.11.2999.a7cc81913bb → 22.11.3184.9b8e5abb183
arkenfox-userjs: 109.0 → 110.0