### PR TITLE
nix(deps): update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1678872516,
-        "narHash": "sha256-/E1YwtMtFAu2KUQKV/1+KFuReYPANM2Rzehk84VxVoc=",
+        "lastModified": 1679472241,
+        "narHash": "sha256-VK2YDic2NjPvfsuneJCLIrWS38qUfoW8rLLimx0rWXA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9b8e5abb18324c7fe9f07cb100c3cd4a29cda8b8",
+        "rev": "9ef6e7727f4c31507627815d4f8679c5841efb00",
         "type": "github"
       },
       "original": {

--- a/pkgs/_sources/generated.json
+++ b/pkgs/_sources/generated.json
@@ -93,11 +93,11 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-eOgjJLRbqa1Omc75Ryjl9MJX4Y3uaHUmy7EjcCSw6CM=",
+            "sha256": "sha256-2PiZzQAtxKOHMkxxAhRnerRy4iKzltSrN/iZWbfpYq4=",
             "type": "url",
-            "url": "https://releases.nixos.org/nixos/22.11/nixos-22.11.3184.9b8e5abb183/nixexprs.tar.xz"
+            "url": "https://releases.nixos.org/nixos/22.11/nixos-22.11.3299.9ef6e7727f4/nixexprs.tar.xz"
         },
-        "version": "22.11.3184.9b8e5abb183"
+        "version": "22.11.3299.9ef6e7727f4"
     },
     "remote-containers": {
         "cargoLocks": null,

--- a/pkgs/_sources/generated.nix
+++ b/pkgs/_sources/generated.nix
@@ -49,10 +49,10 @@
   };
   programs-db = {
     pname = "programs-db";
-    version = "22.11.3184.9b8e5abb183";
+    version = "22.11.3299.9ef6e7727f4";
     src = fetchurl {
-      url = "https://releases.nixos.org/nixos/22.11/nixos-22.11.3184.9b8e5abb183/nixexprs.tar.xz";
-      sha256 = "sha256-eOgjJLRbqa1Omc75Ryjl9MJX4Y3uaHUmy7EjcCSw6CM=";
+      url = "https://releases.nixos.org/nixos/22.11/nixos-22.11.3299.9ef6e7727f4/nixexprs.tar.xz";
+      sha256 = "sha256-2PiZzQAtxKOHMkxxAhRnerRy4iKzltSrN/iZWbfpYq4=";
     };
   };
   remote-containers = {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/9b8e5abb18324c7fe9f07cb100c3cd4a29cda8b8' (2023-03-15)
  → 'github:NixOS/nixpkgs/9ef6e7727f4c31507627815d4f8679c5841efb00' (2023-03-22)

Nvfetcher updates:

programs-db: 22.11.3184.9b8e5abb183 → 22.11.3299.9ef6e7727f4