### PR TITLE
nix(deps): update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1679472241,
-        "narHash": "sha256-VK2YDic2NjPvfsuneJCLIrWS38qUfoW8rLLimx0rWXA=",
+        "lastModified": 1680122840,
+        "narHash": "sha256-zCQ/9iFHzCW5JMYkkHMwgK1/1/kTMgCMHq4THPINpAU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9ef6e7727f4c31507627815d4f8679c5841efb00",
+        "rev": "a575c243c23e2851b78c00e9fa245232926ec32f",
         "type": "github"
       },
       "original": {

--- a/pkgs/_sources/generated.json
+++ b/pkgs/_sources/generated.json
@@ -13,11 +13,11 @@
             "name": null,
             "owner": "arkenfox",
             "repo": "user.js",
-            "rev": "110.0",
-            "sha256": "sha256-pPJH69y29aV1fc3lrlPl5pMLB5ntem+DcAR3rx3gvDE=",
+            "rev": "111.0",
+            "sha256": "sha256-EutseXvFnDkYq95GWiGrTFqI4fqybvsPQlVV0Wy5tFU=",
             "type": "github"
         },
-        "version": "110.0"
+        "version": "111.0"
     },
     "clash-geoip": {
         "cargoLocks": null,
@@ -93,11 +93,11 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-2PiZzQAtxKOHMkxxAhRnerRy4iKzltSrN/iZWbfpYq4=",
+            "sha256": "sha256-LROC33fdddtRjaIHun6J0pAQkGJIR2M4a7t1yv6OB4U=",
             "type": "url",
-            "url": "https://releases.nixos.org/nixos/22.11/nixos-22.11.3299.9ef6e7727f4/nixexprs.tar.xz"
+            "url": "https://releases.nixos.org/nixos/22.11/nixos-22.11.3408.a575c243c23/nixexprs.tar.xz"
         },
-        "version": "22.11.3299.9ef6e7727f4"
+        "version": "22.11.3408.a575c243c23"
     },
     "remote-containers": {
         "cargoLocks": null,

--- a/pkgs/_sources/generated.nix
+++ b/pkgs/_sources/generated.nix
@@ -3,13 +3,13 @@
 {
   arkenfox-userjs = {
     pname = "arkenfox-userjs";
-    version = "110.0";
+    version = "111.0";
     src = fetchFromGitHub ({
       owner = "arkenfox";
       repo = "user.js";
-      rev = "110.0";
+      rev = "111.0";
       fetchSubmodules = false;
-      sha256 = "sha256-pPJH69y29aV1fc3lrlPl5pMLB5ntem+DcAR3rx3gvDE=";
+      sha256 = "sha256-EutseXvFnDkYq95GWiGrTFqI4fqybvsPQlVV0Wy5tFU=";
     });
   };
   clash-geoip = {
@@ -49,10 +49,10 @@
   };
   programs-db = {
     pname = "programs-db";
-    version = "22.11.3299.9ef6e7727f4";
+    version = "22.11.3408.a575c243c23";
     src = fetchurl {
-      url = "https://releases.nixos.org/nixos/22.11/nixos-22.11.3299.9ef6e7727f4/nixexprs.tar.xz";
-      sha256 = "sha256-2PiZzQAtxKOHMkxxAhRnerRy4iKzltSrN/iZWbfpYq4=";
+      url = "https://releases.nixos.org/nixos/22.11/nixos-22.11.3408.a575c243c23/nixexprs.tar.xz";
+      sha256 = "sha256-LROC33fdddtRjaIHun6J0pAQkGJIR2M4a7t1yv6OB4U=";
     };
   };
   remote-containers = {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/9ef6e7727f4c31507627815d4f8679c5841efb00' (2023-03-22)
  → 'github:NixOS/nixpkgs/a575c243c23e2851b78c00e9fa245232926ec32f' (2023-03-29)

Nvfetcher updates:

arkenfox-userjs: 110.0 → 111.0
programs-db: 22.11.3299.9ef6e7727f4 → 22.11.3408.a575c243c23