### PR TITLE
nix(deps): update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1678901627,
-        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "lastModified": 1680776469,
+        "narHash": "sha256-3CXUDK/3q/kieWtdsYpDOBJw3Gw4Af6x+2EiSnIkNQw=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "rev": "411e8764155aa9354dbcd6d5faaeb97e9e3dce24",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1680122840,
-        "narHash": "sha256-zCQ/9iFHzCW5JMYkkHMwgK1/1/kTMgCMHq4THPINpAU=",
+        "lastModified": 1680665430,
+        "narHash": "sha256-MTVhTukwza1Jlq2gECITZPFnhROmylP2uv3O3cSqQCE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a575c243c23e2851b78c00e9fa245232926ec32f",
+        "rev": "5233fd2ba76a3accb5aaa999c00509a11fd0793c",
         "type": "github"
       },
       "original": {

--- a/pkgs/_sources/generated.json
+++ b/pkgs/_sources/generated.json
@@ -93,11 +93,11 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-LROC33fdddtRjaIHun6J0pAQkGJIR2M4a7t1yv6OB4U=",
+            "sha256": "sha256-EL6h1UvLxM/hhb9fMdhNqK34Dq49gYoGUd8GKq6MfK0=",
             "type": "url",
-            "url": "https://releases.nixos.org/nixos/22.11/nixos-22.11.3408.a575c243c23/nixexprs.tar.xz"
+            "url": "https://releases.nixos.org/nixos/22.11/nixos-22.11.3546.5233fd2ba76/nixexprs.tar.xz"
         },
-        "version": "22.11.3408.a575c243c23"
+        "version": "22.11.3546.5233fd2ba76"
     },
     "remote-containers": {
         "cargoLocks": null,

--- a/pkgs/_sources/generated.nix
+++ b/pkgs/_sources/generated.nix
@@ -49,10 +49,10 @@
   };
   programs-db = {
     pname = "programs-db";
-    version = "22.11.3408.a575c243c23";
+    version = "22.11.3546.5233fd2ba76";
     src = fetchurl {
-      url = "https://releases.nixos.org/nixos/22.11/nixos-22.11.3408.a575c243c23/nixexprs.tar.xz";
-      sha256 = "sha256-LROC33fdddtRjaIHun6J0pAQkGJIR2M4a7t1yv6OB4U=";
+      url = "https://releases.nixos.org/nixos/22.11/nixos-22.11.3546.5233fd2ba76/nixexprs.tar.xz";
+      sha256 = "sha256-EL6h1UvLxM/hhb9fMdhNqK34Dq49gYoGUd8GKq6MfK0=";
     };
   };
   remote-containers = {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'flake-utils':
    'github:numtide/flake-utils/93a2b84fc4b70d9e089d029deacc3583435c2ed6' (2023-03-15)
  → 'github:numtide/flake-utils/411e8764155aa9354dbcd6d5faaeb97e9e3dce24' (2023-04-06)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/a575c243c23e2851b78c00e9fa245232926ec32f' (2023-03-29)
  → 'github:NixOS/nixpkgs/5233fd2ba76a3accb5aaa999c00509a11fd0793c' (2023-04-05)

Nvfetcher updates:

programs-db: 22.11.3408.a575c243c23 → 22.11.3546.5233fd2ba76