### PR TITLE
nix(deps): update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1681932375,
-        "narHash": "sha256-tSXbYmpnKSSWpzOrs27ie8X3I0yqKA6AuCzCYNtwbCU=",
+        "lastModified": 1682538316,
+        "narHash": "sha256-YuHgVsR7S9zxJWHo7lo2ugd+uDC4ESWg1hA4bEZQv3Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3d302c67ab8647327dba84fbdb443cdbf0e82744",
+        "rev": "15b75800dce80225b44f067c9012b09de37dfad2",
         "type": "github"
       },
       "original": {

--- a/pkgs/_sources/generated.json
+++ b/pkgs/_sources/generated.json
@@ -78,11 +78,11 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-tE2Q7NM+cQOg+vyqyfRwg05EOMQWhhggTA6S+VT+SkM=",
+            "sha256": "sha256-h4TZzExl1zThwzlKBtL0u3V1jFjjNM2Cscy4hGir9Ts=",
             "type": "url",
-            "url": "https://github.com/agalwood/Motrix/releases/download/v1.6.11/Motrix-1.6.11.AppImage"
+            "url": "https://github.com/agalwood/Motrix/releases/download/v1.8.14/Motrix-1.8.14.AppImage"
         },
-        "version": "1.6.11"
+        "version": "1.8.14"
     },
     "programs-db": {
         "cargoLocks": null,
@@ -93,11 +93,11 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-B9Oa8qMSTKWqvNfuLZrh3ekND2XiVOkYd+rNdfnaAys=",
+            "sha256": "sha256-Y6CsjjFa0BqDswsY5cBMtjom+XQk2cvu5c2PLQjTq/o=",
             "type": "url",
-            "url": "https://releases.nixos.org/nixos/22.11/nixos-22.11.3810.3d302c67ab8/nixexprs.tar.xz"
+            "url": "https://releases.nixos.org/nixos/22.11/nixos-22.11.3940.15b75800dce/nixexprs.tar.xz"
         },
-        "version": "22.11.3810.3d302c67ab8"
+        "version": "22.11.3940.15b75800dce"
     },
     "remote-containers": {
         "cargoLocks": null,

--- a/pkgs/_sources/generated.nix
+++ b/pkgs/_sources/generated.nix
@@ -41,18 +41,18 @@
   };
   motrix = {
     pname = "motrix";
-    version = "1.6.11";
+    version = "1.8.14";
     src = fetchurl {
-      url = "https://github.com/agalwood/Motrix/releases/download/v1.6.11/Motrix-1.6.11.AppImage";
-      sha256 = "sha256-tE2Q7NM+cQOg+vyqyfRwg05EOMQWhhggTA6S+VT+SkM=";
+      url = "https://github.com/agalwood/Motrix/releases/download/v1.8.14/Motrix-1.8.14.AppImage";
+      sha256 = "sha256-h4TZzExl1zThwzlKBtL0u3V1jFjjNM2Cscy4hGir9Ts=";
     };
   };
   programs-db = {
     pname = "programs-db";
-    version = "22.11.3810.3d302c67ab8";
+    version = "22.11.3940.15b75800dce";
     src = fetchurl {
-      url = "https://releases.nixos.org/nixos/22.11/nixos-22.11.3810.3d302c67ab8/nixexprs.tar.xz";
-      sha256 = "sha256-B9Oa8qMSTKWqvNfuLZrh3ekND2XiVOkYd+rNdfnaAys=";
+      url = "https://releases.nixos.org/nixos/22.11/nixos-22.11.3940.15b75800dce/nixexprs.tar.xz";
+      sha256 = "sha256-Y6CsjjFa0BqDswsY5cBMtjom+XQk2cvu5c2PLQjTq/o=";
     };
   };
   remote-containers = {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/3d302c67ab8647327dba84fbdb443cdbf0e82744' (2023-04-19)
  → 'github:NixOS/nixpkgs/15b75800dce80225b44f067c9012b09de37dfad2' (2023-04-26)

Nvfetcher updates:

motrix: 1.6.11 → 1.8.14
programs-db: 22.11.3810.3d302c67ab8 → 22.11.3940.15b75800dce